### PR TITLE
docs: add SonarCloud quality gate and metrics badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [![Coverage Status](https://coveralls.io/repos/github/jpourdanis/test-automation-best-practices/badge.svg?branch=main)](https://coveralls.io/github/jpourdanis/test-automation-best-practices?branch=main)
 [![CI](https://github.com/jpourdanis/test-automation-best-practices/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/jpourdanis/test-automation-best-practices/actions/workflows/ci.yml)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=jpourdanis_test-automation-best-practices&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=jpourdanis_test-automation-best-practices)
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=jpourdanis_test-automation-best-practices&metric=bugs)](https://sonarcloud.io/summary/new_code?id=jpourdanis_test-automation-best-practices)
+[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=jpourdanis_test-automation-best-practices&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=jpourdanis_test-automation-best-practices)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=jpourdanis_test-automation-best-practices&metric=coverage)](https://sonarcloud.io/summary/new_code?id=jpourdanis_test-automation-best-practices)
 [![Passed Tests](https://img.shields.io/badge/dynamic/json?color=success&label=Passed&query=%24.statistic.passed&url=https%3A%2F%2Fjpourdanis.github.io%2Ftest-automation-best-practices%2Fwidgets%2Fsummary.json)](https://jpourdanis.github.io/test-automation-best-practices/)
 [![Failed Tests](https://img.shields.io/badge/dynamic/json?color=critical&label=Failed&query=%24.statistic.failed&url=https%3A%2F%2Fjpourdanis.github.io%2Ftest-automation-best-practices%2Fwidgets%2Fsummary.json)](https://jpourdanis.github.io/test-automation-best-practices/)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added SonarCloud status badges (Quality Gate Status, Bugs, Code Smells, and Coverage) to the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->