### PR TITLE
fix: add file extensions to NYC configuration for coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,6 +140,12 @@
     ]
   },
   "nyc": {
+    "extension": [
+      ".js",
+      ".jsx",
+      ".ts",
+      ".tsx"
+    ],
     "exclude": [
       "src/setupProxy.js",
       "src/index.tsx",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage configuration to properly instrument JavaScript, JSX, TypeScript, and TSX files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->