### PR TITLE
feat(api): add POST /api/reseed endpoint with Bearer token auth

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ services:
     environment:
       - MONGO_URI=mongodb://mongo:27017/colorsdb
       - RATE_LIMIT_MAX=1000000
+      - RESEED_API_TOKEN=${RESEED_API_TOKEN}
 
   mongo:
     image: mongo:latest
@@ -83,6 +84,7 @@ services:
       - BASE_URL=http://web:3000
       - CI=true
       - HOST_WORKSPACE_PATH=${GITHUB_WORKSPACE}
+      - RESEED_API_TOKEN=${RESEED_API_TOKEN}
     tty: true
     stdin_open: true
     user: root

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,22 +1,48 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
-import { FullConfig } from '@playwright/test'
+import { request } from '@playwright/test'
 
-async function globalSetup(config: FullConfig) {
+async function globalSetup() {
   const istanbulCLIOutput = path.join(process.cwd(), '.nyc_output')
 
   if (fs.existsSync(istanbulCLIOutput)) {
     try {
       fs.rmSync(istanbulCLIOutput, { recursive: true, force: true })
       console.log(`[Global Setup] Deleted existing .nyc_output folder`)
-    } catch (err: any) {
-      console.warn(`[Global Setup] Could not remove .nyc_output: ${err?.message || err}`)
+    } catch (err: unknown) {
+      console.warn(`[Global Setup] Could not remove .nyc_output: ${err instanceof Error ? err.message : err}`)
     }
   }
 
   if (!fs.existsSync(istanbulCLIOutput)) {
     fs.mkdirSync(istanbulCLIOutput, { recursive: true })
     console.log(`[Global Setup] Created .nyc_output folder`)
+  }
+
+  // Reseed the database once before all tests to guarantee a clean baseline.
+  // Individual suites that mutate data add their own beforeEach reseed on top.
+  const baseURL = process.env.BASE_URL ?? 'http://localhost:3000'
+  const token = process.env.RESEED_API_TOKEN
+  if (token) {
+    const context = await request.newContext({ baseURL })
+    try {
+      const res = await context.post('/api/reseed', {
+        headers: { Authorization: `Bearer ${token}` }
+      })
+      if (res.ok()) {
+        console.log('[Global Setup] Database reseeded successfully')
+      } else {
+        console.warn(`[Global Setup] Reseed returned HTTP ${res.status()} — continuing anyway`)
+      }
+    } catch (err: unknown) {
+      console.warn(
+        `[Global Setup] Reseed request failed: ${err instanceof Error ? err.message : err} — continuing anyway`
+      )
+    } finally {
+      await context.dispose()
+    }
+  } else {
+    console.warn('[Global Setup] RESEED_API_TOKEN not set — skipping database reseed')
   }
 }
 

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -26,18 +26,16 @@ async function globalSetup() {
   if (token) {
     const context = await request.newContext({ baseURL })
     try {
-      const res = await context.post('/api/reseed', {
-        headers: { Authorization: `Bearer ${token}` }
-      })
+      const res = await context
+        .post('/api/reseed', { headers: { Authorization: `Bearer ${token}` } })
+        .catch((err: unknown) => {
+          throw new Error(`[Global Setup] Reseed request failed: ${err instanceof Error ? err.message : err}`)
+        })
       if (res.ok()) {
         console.log('[Global Setup] Database reseeded successfully')
       } else {
-        console.warn(`[Global Setup] Reseed returned HTTP ${res.status()} — continuing anyway`)
+        throw new Error(`[Global Setup] Reseed returned HTTP ${res.status()}`)
       }
-    } catch (err: unknown) {
-      console.warn(
-        `[Global Setup] Reseed request failed: ${err instanceof Error ? err.message : err} — continuing anyway`
-      )
     } finally {
       await context.dispose()
     }

--- a/e2e/helper.ts
+++ b/e2e/helper.ts
@@ -1,4 +1,22 @@
 import * as crypto from 'node:crypto'
+import type { APIRequestContext } from '@playwright/test'
+
+/**
+ * Calls POST /api/reseed with the RESEED_API_TOKEN env var to restore the
+ * database to its default seed state (Turquoise, Red, Yellow).
+ * Use in beforeEach / beforeAll hooks for suites that mutate or depend on
+ * the exact set of seed colors.
+ */
+export async function reseedDatabase(request: APIRequestContext): Promise<void> {
+  const token = process.env.RESEED_API_TOKEN
+  if (!token) throw new Error('RESEED_API_TOKEN is not set — add it to server/.env or set it in the environment')
+  const res = await request.post('/api/reseed', {
+    headers: { Authorization: `Bearer ${token}` }
+  })
+  if (!res.ok()) {
+    throw new Error(`reseedDatabase failed: HTTP ${res.status()} — ${await res.text()}`)
+  }
+}
 /**
  * Converts a hexadecimal color string to RGB values
  * @param hex - The hexadecimal color string (with or without '#' prefix)
@@ -7,14 +25,14 @@ import * as crypto from 'node:crypto'
  * convertHexToRGB('#1abc9c') // returns { red: 26, green: 188, blue: 156 }
  * convertHexToRGB('1abc9c')  // returns { red: 26, green: 188, blue: 156 }
  */
-export function convertHexToRGB(hex: any) {
+export function convertHexToRGB(hex: string) {
   // Remove the '#' if it's included in the input
   hex = hex.replace(/^#/, '')
 
   // Parse the hex values into separate R, G, and B values
-  const red = parseInt(hex.substring(0, 2), 16)
-  const green = parseInt(hex.substring(2, 4), 16)
-  const blue = parseInt(hex.substring(4, 6), 16)
+  const red = Number.parseInt(hex.substring(0, 2), 16)
+  const green = Number.parseInt(hex.substring(2, 4), 16)
+  const blue = Number.parseInt(hex.substring(4, 6), 16)
 
   // Return the RGB values in an object
   return {
@@ -32,7 +50,7 @@ export function convertHexToRGB(hex: any) {
  * extractHexColor('Current color: #1abc9c') // returns '1abc9c'
  * extractHexColor('No color here')          // returns null
  */
-export function extractHexColor(text: any) {
+export function extractHexColor(text: string) {
   const hexMatch = text.match(/#([0-9a-fA-F]{6})/)
   if (hexMatch) {
     return hexMatch[1]

--- a/e2e/tests/api.spec.ts
+++ b/e2e/tests/api.spec.ts
@@ -12,6 +12,8 @@ import { ColorSchema } from '@color-app/shared'
  * live API responses against the shared type definitions.
  */
 test.describe('Backend API Integration', () => {
+  // Track colors created within this worker so afterEach can clean them up.
+  // Each worker in the parallel run has its own copy of this variable.
   let createdColorName: string | null = null
 
   test.afterEach(async ({ request }) => {
@@ -99,7 +101,7 @@ test.describe('Backend API Integration', () => {
     test('should create a new color with valid schema', async ({ request }) => {
       const uniqueName = faker.string.alphanumeric(15)
       const newColor = { name: uniqueName, hex: '#ffa500' }
-      createdColorName = newColor.name
+      createdColorName = uniqueName
       const response = await request.post(`/api/colors`, { data: newColor })
       expect(response.status()).toBe(201)
 
@@ -111,7 +113,7 @@ test.describe('Backend API Integration', () => {
     test('should return 409 for duplicate color creation', async ({ request }) => {
       const uniqueName = faker.string.alphanumeric(15)
       const color = { name: uniqueName, hex: '#111111' }
-      createdColorName = color.name
+      createdColorName = uniqueName
       await request.post(`/api/colors`, { data: color })
 
       const response = await request.post(`/api/colors`, { data: color })
@@ -165,7 +167,7 @@ test.describe('Backend API Integration', () => {
     test('should update a color with valid schema', async ({ request }) => {
       const uniqueName = faker.string.alphanumeric(15)
       const tempColor = { name: uniqueName, hex: '#112233' }
-      createdColorName = tempColor.name
+      createdColorName = uniqueName
       await request.post(`/api/colors`, { data: tempColor })
 
       const updateData = { hex: '#332211' }
@@ -220,7 +222,6 @@ test.describe('Backend API Integration', () => {
     test('should delete an existing color', async ({ request }) => {
       const uniqueName = faker.string.alphanumeric(15)
       const color = { name: uniqueName, hex: '#333333' }
-      createdColorName = color.name
       await request.post(`/api/colors`, { data: color })
 
       const response = await request.delete(`/api/colors/${color.name}`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
       ],
       "dependencies": {
         "@color-app/shared": "*",
-        "@esbuild/linux-arm64": "0.28.0",
         "@playwright/test": "^1.59.1",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42983,9 +42983,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "node-forge": "^1.3.0",
     "js-yaml": "^4.1.1",
     "axios": ">=1.15.2",
-    "underscore": "^1.13.8"
+    "underscore": "^1.13.8",
+    "tmp": "^0.2.6"
   },
   "dependencies": {
     "@color-app/shared": "*",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,19 @@
 import { PlaywrightTestConfig, devices } from '@playwright/test'
 import { defineBddConfig } from 'playwright-bdd'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+// When running locally, load RESEED_API_TOKEN from server/.env so test hooks
+// can call POST /api/reseed. In CI/Docker the var is injected via the environment.
+if (!process.env.RESEED_API_TOKEN) {
+  try {
+    const envContent = fs.readFileSync(path.join(__dirname, 'server', '.env'), 'utf8')
+    const match = envContent.match(/^RESEED_API_TOKEN=(.+)$/m)
+    if (match) process.env.RESEED_API_TOKEN = match[1].trim()
+  } catch {
+    /* file absent; RESEED_API_TOKEN must be set externally */
+  }
+}
 
 const testDir = defineBddConfig({
   features: 'e2e/features/*.feature',
@@ -12,9 +26,6 @@ const isPercyEnabled = !!process.env.PERCY_TOKEN
 // Tests that don't make sense on BrowserStack: visual diffs are environment-specific
 // and BDD tests are covered by the Chrome project already
 const BS_IGNORE = [/.*visual\.spec\.ts$/, /.*\.feature\.spec.*$/]
-
-// For Percy on production: run visual tests against the production URL
-const PERCY_PROJECTS = isPercyEnabled ? ['Percy Visual'] : []
 
 const config: PlaywrightTestConfig = {
   // If a test fails then passes on a retry, Allure marks it as flaky automatically.

--- a/server/.env.example
+++ b/server/.env.example
@@ -4,3 +4,7 @@ PORT=5001
 # MongoDB Connection String
 # Example: MONGODB_URI_HERE (e.g. mongodb+srv://user:password@host/db)
 MONGO_URI=YOUR_MONGODB_CONNECTION_STRING_HERE
+
+# API token for the POST /api/reseed endpoint (test utility)
+# Use a long, random string and keep it secret
+RESEED_API_TOKEN=YOUR_RESEED_TOKEN_HERE

--- a/server/index.int.test.js
+++ b/server/index.int.test.js
@@ -1,9 +1,9 @@
-/* eslint-env jest */
+/* global describe, it, expect, jest, beforeAll, beforeEach, afterAll, afterEach */
 const request = require('supertest')
 const { MongoDBContainer } = require('@testcontainers/mongodb')
 const mongoose = require('mongoose')
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
 
 let app, seedDatabase, Color, mongodbContainer
 
@@ -22,7 +22,7 @@ describe('Server Integration Tests (Testcontainers)', () => {
             process.env.DOCKER_HOST = config.DOCKER_HOST
           }
         }
-      } catch (e) {
+      } catch {
         // Fallback to default Testcontainers detection
       }
     }
@@ -343,6 +343,78 @@ describe('Server Integration Tests (Testcontainers)', () => {
       expect(res.headers.allow).toContain('GET')
       expect(res.headers.allow).toContain('PUT')
       expect(res.headers.allow).toContain('DELETE')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // POST /api/reseed
+  // ---------------------------------------------------------------------------
+
+  describe('POST /api/reseed', () => {
+    const validToken = 'integration-reseed-secret'
+
+    beforeEach(() => {
+      process.env.RESEED_API_TOKEN = validToken
+    })
+
+    afterEach(() => {
+      delete process.env.RESEED_API_TOKEN
+    })
+
+    it('should reseed the database to the three default colors with a valid token', async () => {
+      await request(app).post('/api/colors').send({ name: 'Custom', hex: '#aabbcc' })
+      let colors = await request(app).get('/api/colors')
+      expect(colors.body).toHaveLength(4)
+
+      const res = await request(app).post('/api/reseed').set('Authorization', `Bearer ${validToken}`)
+
+      expect(res.status).toBe(200)
+      expect(res.body.message).toBe('Database reseeded successfully')
+
+      colors = await request(app).get('/api/colors')
+      expect(colors.body).toHaveLength(3)
+      const names = colors.body.map((c) => c.name)
+      expect(names).toEqual(expect.arrayContaining(['Turquoise', 'Red', 'Yellow']))
+      expect(names).not.toContain('Custom')
+    })
+
+    it('should be idempotent — calling reseed twice always yields exactly 3 colors', async () => {
+      await request(app).post('/api/reseed').set('Authorization', `Bearer ${validToken}`)
+      const res = await request(app).post('/api/reseed').set('Authorization', `Bearer ${validToken}`)
+      expect(res.status).toBe(200)
+
+      const colors = await request(app).get('/api/colors')
+      expect(colors.body).toHaveLength(3)
+    })
+
+    it('should return 401 when Authorization header is missing', async () => {
+      const res = await request(app).post('/api/reseed')
+      expect(res.status).toBe(401)
+      expect(res.body.error).toBe('Unauthorized')
+    })
+
+    it('should return 401 when token is invalid', async () => {
+      const res = await request(app).post('/api/reseed').set('Authorization', 'Bearer invalid-token')
+      expect(res.status).toBe(401)
+      expect(res.body.error).toBe('Unauthorized')
+    })
+
+    it('should return 405 for GET on /api/reseed', async () => {
+      const res = await request(app).get('/api/reseed')
+      expect(res.status).toBe(405)
+      expect(res.body.error).toBe('Method GET not allowed on /api/reseed')
+      expect(res.headers.allow).toBe('POST')
+    })
+
+    it('should not modify the database when token is invalid', async () => {
+      await Color.deleteMany({})
+      await Color.insertMany([{ name: 'OnlyColor', hex: '#123456' }])
+
+      await request(app).post('/api/reseed').set('Authorization', 'Bearer wrong-token')
+
+      const colors = await Color.find({}).lean()
+      expect(colors).toHaveLength(1)
+      expect(colors[0].name).toBe('OnlyColor')
     })
   })
 

--- a/server/index.js
+++ b/server/index.js
@@ -75,7 +75,15 @@ const swaggerOptions = {
         url: `http://localhost:${process.env.PORT || 5001}`,
         description: 'Local development server'
       }
-    ]
+    ],
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer'
+        }
+      }
+    }
   },
   // Scan this and api/index.js for JSDoc @swagger annotations
   apis: [__filename, 'api/index.js']
@@ -195,6 +203,7 @@ const seedDatabase = async () => {
   } catch (error) {
     // Stryker disable next-line all: error logging only
     console.error('Error seeding database:', error)
+    throw error
   }
 }
 
@@ -220,6 +229,16 @@ if (require.main === module) {
 // 405 Method Not Allowed Handler
 // ---------------------------------------------------------------------------
 
+// Validates the Bearer token in the Authorization header against RESEED_API_TOKEN env var.
+const authenticateApiToken = (req, res, next) => {
+  const authHeader = req.headers.authorization
+  const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null
+  if (!token || token !== process.env.RESEED_API_TOKEN) {
+    return res.status(401).json({ error: 'Unauthorized' })
+  }
+  next()
+}
+
 /**
  * Middleware to catch methods that are not explicitly defined on existing routes
  * and return 405 Method Not Allowed instead of 404 Not Found.
@@ -228,6 +247,7 @@ if (require.main === module) {
 const allowedMethods = {
   '/api/colors': ['GET', 'POST'],
   '/api/colors/:name': ['GET', 'PUT', 'DELETE'],
+  '/api/reseed': ['POST'],
   '/openapi.json': ['GET'],
   '/api-docs': ['GET']
 }
@@ -244,6 +264,14 @@ app.all('/api/colors/:name', (req, res, next) => {
   if (!allowedMethods['/api/colors/:name'].includes(req.method)) {
     res.setHeader('Allow', allowedMethods['/api/colors/:name'].join(', '))
     return res.status(405).json({ error: `Method ${req.method} not allowed on /api/colors/:name` })
+  }
+  next()
+})
+
+app.all('/api/reseed', (req, res, next) => {
+  if (!allowedMethods['/api/reseed'].includes(req.method)) {
+    res.setHeader('Allow', allowedMethods['/api/reseed'].join(', '))
+    return res.status(405).json({ error: `Method ${req.method} not allowed on /api/reseed` })
   }
   next()
 })
@@ -548,6 +576,55 @@ app.delete('/api/colors/:name', async (req, res) => {
 })
 
 // ---------------------------------------------------------------------------
+// POST /api/reseed – Reset database to default seed state (test utility)
+// ---------------------------------------------------------------------------
+
+/**
+ * @swagger
+ * /api/reseed:
+ *   post:
+ *     summary: Reseed the database with default colors
+ *     description: >
+ *       Resets the database to the default seed state (Turquoise, Red, Yellow).
+ *       Requires a valid Bearer token via the Authorization header.
+ *       Intended for use in test suite before/beforeEach hooks to guarantee a clean state.
+ *     tags: [Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Database reseeded successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Database reseeded successfully
+ *       401:
+ *         description: Unauthorized — missing or invalid Bearer token
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Failed to reseed database
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+app.post('/api/reseed', authenticateApiToken, async (req, res) => {
+  try {
+    await seedDatabase()
+    res.json({ message: 'Database reseeded successfully' })
+  } catch {
+    res.status(500).json({ error: 'Failed to reseed database' })
+  }
+})
+
+// ---------------------------------------------------------------------------
 // Start the server
 // ---------------------------------------------------------------------------
 
@@ -562,4 +639,4 @@ if (require.main === module) {
 }
 // Stryker restore all
 
-module.exports = { app, seedDatabase, Color, mongoose, MONGO_URI, swaggerSpec }
+module.exports = { app, seedDatabase, authenticateApiToken, Color, mongoose, MONGO_URI, swaggerSpec }

--- a/server/index.test.js
+++ b/server/index.test.js
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+/* global describe, it, expect, jest, beforeAll, beforeEach, afterAll, afterEach */
 const request = require('supertest')
 const { MongoMemoryServer } = require('mongodb-memory-server')
 const mongoose = require('mongoose')
@@ -446,6 +446,84 @@ describe('Server Unit Tests', () => {
   })
 
   // =========================================================================
+  // POST /api/reseed
+  // =========================================================================
+  describe('POST /api/reseed', () => {
+    const validToken = 'test-reseed-secret'
+
+    beforeEach(() => {
+      process.env.RESEED_API_TOKEN = validToken
+    })
+
+    afterEach(() => {
+      delete process.env.RESEED_API_TOKEN
+    })
+
+    it('returns 200 and reseeds the database with a valid token', async () => {
+      await Color.create({ name: 'Extra', hex: '#ffffff' })
+      expect(await Color.countDocuments()).toBe(4)
+
+      const res = await request(app).post('/api/reseed').set('Authorization', `Bearer ${validToken}`)
+
+      expect(res.status).toBe(200)
+      expect(res.body.message).toBe('Database reseeded successfully')
+      expect(await Color.countDocuments()).toBe(3)
+
+      const names = (await Color.find({}, { _id: 0, __v: 0 }).lean()).map((c) => c.name)
+      expect(names).toEqual(expect.arrayContaining(['Turquoise', 'Red', 'Yellow']))
+      expect(names).not.toContain('Extra')
+    })
+
+    it('returns 401 when Authorization header is missing', async () => {
+      const res = await request(app).post('/api/reseed')
+      expect(res.status).toBe(401)
+      expect(res.body.error).toBe('Unauthorized')
+    })
+
+    it('returns 401 when token is incorrect', async () => {
+      const res = await request(app).post('/api/reseed').set('Authorization', 'Bearer wrong-token')
+      expect(res.status).toBe(401)
+      expect(res.body.error).toBe('Unauthorized')
+    })
+
+    it('returns 401 when Bearer scheme prefix is missing', async () => {
+      const res = await request(app).post('/api/reseed').set('Authorization', validToken)
+      expect(res.status).toBe(401)
+      expect(res.body.error).toBe('Unauthorized')
+    })
+
+    it('returns 401 when RESEED_API_TOKEN is not configured', async () => {
+      delete process.env.RESEED_API_TOKEN
+      const res = await request(app).post('/api/reseed').set('Authorization', `Bearer ${validToken}`)
+      expect(res.status).toBe(401)
+      expect(res.body.error).toBe('Unauthorized')
+    })
+
+    it('returns 405 for GET on /api/reseed', async () => {
+      const res = await request(app).get('/api/reseed')
+      expect(res.status).toBe(405)
+      expect(res.body.error).toBe('Method GET not allowed on /api/reseed')
+      expect(res.headers.allow).toBe('POST')
+    })
+
+    it('returns 405 for PUT on /api/reseed', async () => {
+      const res = await request(app).put('/api/reseed')
+      expect(res.status).toBe(405)
+      expect(res.body.error).toBe('Method PUT not allowed on /api/reseed')
+      expect(res.headers.allow).toBe('POST')
+    })
+
+    it('returns 500 when seedDatabase throws', async () => {
+      jest.spyOn(Color, 'deleteMany').mockRejectedValueOnce(new Error('DB Error'))
+      jest.spyOn(console, 'error').mockImplementation(() => {})
+      const res = await request(app).post('/api/reseed').set('Authorization', `Bearer ${validToken}`)
+      expect(res.status).toBe(500)
+      expect(res.body.error).toBe('Failed to reseed database')
+      jest.restoreAllMocks()
+    })
+  })
+
+  // =========================================================================
   // Seed database
   // =========================================================================
   describe('seedDatabase', () => {
@@ -665,11 +743,11 @@ describe('Server Unit Tests', () => {
       expect(res.body.error).toBe('Failed to delete color')
     })
 
-    it('seedDatabase logs error when database fails', async () => {
+    it('seedDatabase logs error and re-throws when database fails', async () => {
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
       jest.spyOn(Color, 'deleteMany').mockRejectedValue(new Error('DB Error'))
 
-      await seedDatabase()
+      await expect(seedDatabase()).rejects.toThrow('DB Error')
 
       expect(consoleErrorSpy).toHaveBeenCalledWith('Error seeding database:', expect.any(Error))
       consoleErrorSpy.mockRestore()

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -34,11 +34,14 @@
     "../packages/shared": {
       "name": "@color-app/shared",
       "version": "1.0.0",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
       "devDependencies": {
+        "esbuild": "~0.28.0",
         "openapi-typescript": "^7.8.0",
         "tsup": "^8.5.0",
-        "typescript": "^6.0.0",
-        "zod": "^4.0.0"
+        "typescript": "^6.0.0"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -7419,6 +7422,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -8819,9 +8829,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/server/package.json
+++ b/server/package.json
@@ -45,7 +45,8 @@
     "protobufjs": "^7.5.6",
     "@protobufjs/utf8": "^1.1.1",
     "uuid": "^11.1.1",
-    "qs": "^6.15.2"
+    "qs": "^6.15.2",
+    "tmp": "^0.2.6"
   },
   "standard": {
     "env": [


### PR DESCRIPTION
Adds a protected reseed endpoint to reset the database to default seed state (Turquoise, Red, Yellow), wires it into global-setup and a helper for use in beforeEach hooks, and passes RESEED_API_TOKEN through docker-compose and playwright.config.ts local env loading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a protected API endpoint to reset the database to its default state for testing purposes, secured with token-based authentication.

## Documentation
* Updated environment configuration documentation to include the required API token variable.

## Tests
* Added comprehensive test coverage for the new reseeding functionality, including authorization validation and error handling scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jpourdanis/test-automation-best-practices/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->