### PR TITLE
fix: patch playwright internals for browserstack-node-sdk compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ server/.env
 /server/coverage
 /mobile/e2e/allure-results/
 /mobile/allure-results/
+/log/

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "scripts": {
     "prepare": "node -e \"if (!process.env.CI) { try { require('child_process').execFileSync('husky', [], {stdio: 'inherit'}) } catch (e) { if (e.code !== 'ENOENT') throw e } }\"",
+    "postinstall": "node scripts/patch-playwright-config-loader.js",
     "build:shared": "npm run build -w packages/shared",
     "generate:openapi": "npm run generate:openapi --prefix server",
     "generate:client": "npm run generate:openapi --prefix server && npm run generate:client -w packages/shared",

--- a/scripts/patch-playwright-config-loader.js
+++ b/scripts/patch-playwright-config-loader.js
@@ -3,10 +3,14 @@
 // merged into playwright/lib/common/index.js and removed from the exports map.
 // This script patches both the exports map and creates stub files so the SDK's
 // requirePWModule calls resolve correctly.
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
 
 const playwrightPkgPath = path.join('node_modules', 'playwright', 'package.json')
+if (!fs.existsSync(playwrightPkgPath)) {
+  console.log('postinstall: playwright not found, skipping patch')
+  process.exit(0)
+}
 const pkg = JSON.parse(fs.readFileSync(playwrightPkgPath, 'utf8'))
 let pkgChanged = false
 

--- a/scripts/patch-playwright-config-loader.js
+++ b/scripts/patch-playwright-config-loader.js
@@ -1,0 +1,42 @@
+'use strict'
+// browserstack-node-sdk requires playwright internal files that Playwright 1.60
+// merged into playwright/lib/common/index.js and removed from the exports map.
+// This script patches both the exports map and creates stub files so the SDK's
+// requirePWModule calls resolve correctly.
+const fs = require('fs')
+const path = require('path')
+
+const playwrightPkgPath = path.join('node_modules', 'playwright', 'package.json')
+const pkg = JSON.parse(fs.readFileSync(playwrightPkgPath, 'utf8'))
+let pkgChanged = false
+
+function ensureExportAndStub(exportKey, stubFile, stubContent) {
+  if (!pkg.exports[exportKey]) {
+    pkg.exports[exportKey] = stubFile
+    pkgChanged = true
+    console.log(`postinstall: added ${exportKey} to playwright exports`)
+  }
+  const stubPath = path.join('node_modules', 'playwright', stubFile.replace('./', ''))
+  if (!fs.existsSync(stubPath)) {
+    fs.writeFileSync(stubPath, stubContent)
+    console.log(`postinstall: created ${stubFile} stub`)
+  }
+}
+
+// 1. playwright/lib/common/configLoader.js → was merged into common/index.js
+ensureExportAndStub(
+  './lib/common/configLoader.js',
+  './lib/common/configLoader.js',
+  "'use strict'\nconst { configLoader } = require('./')\nmodule.exports = configLoader || {}\n"
+)
+
+// 2. playwright/lib/transform/transform.js → was merged into common/index.js as 'transform'
+ensureExportAndStub(
+  './lib/transform/transform.js',
+  './lib/transform/transform.js',
+  "'use strict'\nconst { transform } = require('../common/')\nmodule.exports = transform || {}\n"
+)
+
+if (pkgChanged) {
+  fs.writeFileSync(playwrightPkgPath, JSON.stringify(pkg, null, 2) + '\n')
+}


### PR DESCRIPTION
browserstack-node-sdk requires playwright/lib/common/configLoader.js and playwright/lib/transform/transform.js, but Playwright 1.60 consolidated these into playwright/lib/common/index.js and removed them from the package exports map. A postinstall script patches the exports map and creates thin re-export stubs so requirePWModule continues to resolve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced the dependency installation process with automated configuration updates for improved compatibility.
  * Updated version control settings to exclude temporary directories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jpourdanis/test-automation-best-practices/pull/142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->