### PR TITLE
fix(ci): fix release workflow protected-branch push failure and Node 20 deprecation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,9 +48,5 @@ jobs:
 
       - name: Release
         env:
-          # GH_TOKEN must be a PAT (or GitHub App token) whose owner has the
-          # "bypass branch protection" privilege on main. The default GITHUB_TOKEN
-          # cannot push directly to a protected branch even with contents:write,
-          # which causes @semantic-release/git to fail with GH006.
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx semantic-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,10 @@ jobs:
       issues: write
       pull-requests: write
       id-token: write
+    env:
+      # Opt into Node.js 24 action runtime ahead of the forced cutover on June 16 2026.
+      # See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -32,7 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
 
@@ -44,5 +48,9 @@ jobs:
 
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GH_TOKEN must be a PAT (or GitHub App token) whose owner has the
+          # "bypass branch protection" privilege on main. The default GITHUB_TOKEN
+          # cannot push directly to a protected branch even with contents:write,
+          # which causes @semantic-release/git to fail with GH006.
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## Summary

Two issues were identified in `.github/workflows/release.yml` from the failing run at [job 79971027772](https://github.com/jpourdanis/test-automation-best-practices/actions/runs/27097060004/job/79971027772):

### Fix 1 — Protected branch push failure (exit code 1, Step 6)

**Root cause:** `@semantic-release/git` commits the version-bumped `package.json` and generated `CHANGELOG.md`, then pushes directly to `main` via:
```
git push --tags https://github.com/... HEAD:main
```
This is rejected with `GH006: Protected branch update failed` because `main` requires all changes to go through a pull request. The default `GITHUB_TOKEN`, even with `contents: write`, **cannot** bypass branch protection rules.

**Fix:** Switch the Release step from `secrets.GITHUB_TOKEN` to `secrets.GH_TOKEN`. `GH_TOKEN` should be a Personal Access Token (or GitHub App token) belonging to a user/app that has the **"bypass branch protection"** privilege on `main`. This is the [standard semantic-release recommendation](https://semantic-release.gitbook.io/semantic-release/usage/ci-configuration#pushing-version-updates-to-a-protected-branch) for protected branches.

> **Action required:** Create a PAT with `repo` scope (or a GitHub App with `contents: write` + branch bypass), and add it as a repository secret named `GH_TOKEN`.

### Fix 2 — Node.js 20 action runtime deprecation

**Root cause:** `actions/setup-node@v4` runs its own action code on Node.js 20, which GitHub is force-migrating to Node.js 24 on **June 16, 2026**. The runner emits:
```
Node.js 20 actions are deprecated … actions/setup-node@v4
```

**Fix:**
- Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` at the job `env` level (explicitly recommended in the GitHub warning) to opt the action runtime into Node.js 24 immediately.
- Bumped `node-version` from `"22"` to `"24"` so the installed Node.js matches the action runtime.

## Test plan

- [ ] Add a `GH_TOKEN` secret (PAT with `repo` scope + branch-protection bypass for `main`) to the repository
- [ ] Merge this PR and confirm the next CI run triggers the Release workflow without a GH006 error
- [ ] Confirm no Node.js 20 deprecation warnings appear in the workflow logs

https://claude.ai/code/session_01RyrWaYaCyq8ec7gqXRRQpj

---
_Generated by [Claude Code](https://claude.ai/code/session_01RyrWaYaCyq8ec7gqXRRQpj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation to use Node.js 24 for improved performance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->