### PR TITLE
fix(mobile): resolve Modal mock circular-init crash with expo 56

### DIFF
--- a/mobile/__mocks__/ModalMock.js
+++ b/mobile/__mocks__/ModalMock.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const React = require('react')
+
+// Minimal Modal stub used via moduleNameMapper to break the circular
+// mock-initialization chain that appears when expo 56 changes the order
+// in which react-native modules are resolved during jest setup.
+//
+// Without this, mockComponent.js loads the real Modal → AppContainer-dev →
+// LogBox → Text, and Text's requireActual returns a partially-initialized
+// export (circular dep), causing "Cannot read properties of undefined
+// (reading 'constructor')" at mockComponent.js line 42.
+class Modal extends React.Component {
+  static displayName = 'Modal'
+
+  render() {
+    const { children, visible } = this.props
+    return visible === false ? null : React.createElement(React.Fragment, null, children)
+  }
+}
+
+module.exports = Modal

--- a/mobile/jest.config.js
+++ b/mobile/jest.config.js
@@ -3,6 +3,10 @@ module.exports = {
   setupFilesAfterEnv: [],
   testMatch: ['<rootDir>/src/**/*.test.(ts|tsx|js|jsx)'],
   moduleNameMapper: {
+    // Redirect Modal to a minimal stub so that mockComponent.js does not load
+    // the real Modal (which triggers AppContainer-dev → LogBox → Text), avoiding
+    // a circular-initialisation crash introduced by expo 56 dependency changes.
+    '^react-native/Libraries/Modal/Modal$': '<rootDir>/__mocks__/ModalMock.js',
     '^react$': '<rootDir>/node_modules/react',
     '^react/(.*)$': '<rootDir>/node_modules/react/$1',
     '^react-test-renderer$': '<rootDir>/../node_modules/react-test-renderer',


### PR DESCRIPTION
Expo 56 changes transitive dependency resolution order, causing react-native's
mockComponent.js to load the real Modal during jest setup. That triggers:
AppContainer-dev → LogBox → Text, where Text's requireActual returns a
partially-initialised export (circular dep), crashing with
"TypeError: Cannot read properties of undefined (reading 'constructor')".

Redirect react-native/Libraries/Modal/Modal to a minimal React.Component stub
via moduleNameMapper. Since moduleNameMapper applies even to jest.requireActual,
mockComponent.js safely extends the stub without triggering the chain. All three
failing suites (ColorPickerModal, ConfirmDialog, ColorPickerInner) are fixed
because any require('react-native') call previously blew up through this path.

https://claude.ai/code/session_01CViLWbCamCNLzdcj7mQPGC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal testing infrastructure to improve test execution reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->