### PR TITLE
fix(mobile): align react version with react-test-renderer

### DIFF
--- a/mobile/jest.config.js
+++ b/mobile/jest.config.js
@@ -5,8 +5,8 @@ module.exports = {
   moduleNameMapper: {
     '^react$': '<rootDir>/node_modules/react',
     '^react/(.*)$': '<rootDir>/node_modules/react/$1',
-    '^react-test-renderer$': '<rootDir>/../node_modules/react-test-renderer',
-    '^react-test-renderer/(.*)$': '<rootDir>/../node_modules/react-test-renderer/$1',
+    '^react-test-renderer$': '<rootDir>/node_modules/react-test-renderer',
+    '^react-test-renderer/(.*)$': '<rootDir>/node_modules/react-test-renderer/$1',
     '^@testing-library/react-native$': require.resolve('@testing-library/react-native')
   },
   transformIgnorePatterns: [

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -36,7 +36,7 @@
     "expo-localization": "~17.0.8",
     "expo-status-bar": "~3.0.9",
     "i18next": "^26.0.6",
-    "react": "19.1.0",
+    "react": "19.2.7",
     "react-dom": "19.2.6",
     "react-i18next": "^17.0.4",
     "react-native": "0.81.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,7 @@
         "expo-localization": "~17.0.8",
         "expo-status-bar": "~3.0.9",
         "i18next": "^26.0.6",
-        "react": "19.1.0",
+        "react": "19.2.7",
         "react-dom": "19.2.6",
         "react-i18next": "^17.0.4",
         "react-native": "0.81.5",
@@ -122,7 +122,7 @@
         "jest": "^29.7.0",
         "jest-expo": "~54.0.17",
         "jest-junit": "^17.0.0",
-        "react-test-renderer": "^19.2.7",
+        "react-test-renderer": "19.2.7",
         "ts-node": "^10.9.0",
         "typescript": "~5.9.2",
         "webdriverio": "^9.0.0"
@@ -811,9 +811,9 @@
       "license": "MIT"
     },
     "mobile/node_modules/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"


### PR DESCRIPTION
## Summary

- **Root cause**: `mobile/package.json` had `react@19.1.0` paired with `react-test-renderer@19.2.7` — a version mismatch. The `jest.config.js` worked around this by redirecting `react-test-renderer` to the root `node_modules` (which had `19.1.0`), creating a fragile cross-workspace dependency.
- **What broke**: Any PR bumping `react` (e.g., PR #134) or `expo` (PR #136) would diverge the versions further, triggering `TypeError: Cannot read properties of undefined (reading 'constructor')` in `react-native/jest/mockComponent.js`.
- **Fix**: Bumped mobile `react` to `19.2.7` to match `react-test-renderer: 19.2.7`, and updated `jest.config.js` to resolve `react-test-renderer` from mobile's own `node_modules` instead of the root — eliminating the fragile path workaround.

## Test plan

- [x] All 41 mobile unit tests pass locally (`npm run test:unit` in `mobile/`)
- [x] CI: Unit Tests (Mobile) passes
- [ ] Open dependabot PRs #134 and #136 should be unblocked after this merges and they rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated React dependency to v19.2.7.
  * Updated Jest configuration for improved module resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->