### PR TITLE
ci(mobile): reuse existing EAS build for the current commit

### DIFF
--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -233,14 +233,14 @@ jobs:
           echo "Looking for an existing finished build for commit ${GITHUB_SHA} (ios/simulator)..."
           EXISTING_JSON=$(eas build:list \
             --platform ios \
-            --buildProfile simulator \
+            --build-profile simulator \
             --status finished \
-            --nonInteractive \
+            --git-commit-hash "$GITHUB_SHA" \
+            --non-interactive \
             --json \
-            --limit 30 2>/dev/null || echo '[]')
+            --limit 1 2>/dev/null || echo '[]')
 
-          BUILD_JSON=$(echo "$EXISTING_JSON" | jq --arg sha "$GITHUB_SHA" \
-            '[.[] | select(.gitCommitHash == $sha)] | .[0:1]')
+          BUILD_JSON=$(echo "$EXISTING_JSON" | jq '.[0:1]')
 
           if [ "$(echo "$BUILD_JSON" | jq 'length')" -gt 0 ]; then
             echo "Reusing existing EAS build for commit ${GITHUB_SHA}."
@@ -433,14 +433,14 @@ jobs:
           echo "Looking for an existing finished build for commit ${GITHUB_SHA} (android/simulator)..."
           EXISTING_JSON=$(eas build:list \
             --platform android \
-            --buildProfile simulator \
+            --build-profile simulator \
             --status finished \
-            --nonInteractive \
+            --git-commit-hash "$GITHUB_SHA" \
+            --non-interactive \
             --json \
-            --limit 30 2>/dev/null || echo '[]')
+            --limit 1 2>/dev/null || echo '[]')
 
-          BUILD_JSON=$(echo "$EXISTING_JSON" | jq --arg sha "$GITHUB_SHA" \
-            '[.[] | select(.gitCommitHash == $sha)] | .[0:1]')
+          BUILD_JSON=$(echo "$EXISTING_JSON" | jq '.[0:1]')
 
           if [ "$(echo "$BUILD_JSON" | jq 'length')" -gt 0 ]; then
             echo "Reusing existing EAS build for commit ${GITHUB_SHA}."

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -218,10 +218,11 @@ jobs:
       - name: Install EAS CLI
         run: npm install -g eas-cli@18.13.0 --ignore-scripts
 
-      # Submits a new iOS simulator build to EAS for the exact commit under
-      # test and blocks until it finishes (eas build waits by default). This
-      # guarantees the binary under test matches this PR's code, instead of
-      # trusting whatever build happened to be "latest finished" on EAS.
+      # Reuses an existing finished EAS build for this exact commit when one
+      # exists, instead of always submitting a new one. This still guarantees
+      # the binary under test matches this PR's code (the lookup is keyed on
+      # commit SHA), while avoiding unnecessary EAS build-minute usage when a
+      # matching build already exists (e.g. a workflow re-run).
       - name: Build iOS Simulator app on EAS
         working-directory: mobile
         env:
@@ -229,13 +230,30 @@ jobs:
         run: |
           mkdir -p e2e/artifacts
 
-          if ! BUILD_JSON=$(eas build \
+          echo "Looking for an existing finished build for commit ${GITHUB_SHA} (ios/simulator)..."
+          EXISTING_JSON=$(eas build:list \
             --platform ios \
-            --profile simulator \
-            --non-interactive \
-            --json); then
-            echo "::error::EAS build failed or did not finish successfully."
-            exit 1
+            --buildProfile simulator \
+            --status finished \
+            --nonInteractive \
+            --json \
+            --limit 30 2>/dev/null || echo '[]')
+
+          BUILD_JSON=$(echo "$EXISTING_JSON" | jq --arg sha "$GITHUB_SHA" \
+            '[.[] | select(.gitCommitHash == $sha)] | .[0:1]')
+
+          if [ "$(echo "$BUILD_JSON" | jq 'length')" -gt 0 ]; then
+            echo "Reusing existing EAS build for commit ${GITHUB_SHA}."
+          else
+            echo "No existing build found for this commit, submitting a new one."
+            if ! BUILD_JSON=$(eas build \
+              --platform ios \
+              --profile simulator \
+              --non-interactive \
+              --json); then
+              echo "::error::EAS build failed or did not finish successfully."
+              exit 1
+            fi
           fi
 
           STATUS=$(echo "$BUILD_JSON" | jq -r '.[0].status')
@@ -400,10 +418,11 @@ jobs:
       - name: Install EAS CLI
         run: npm install -g eas-cli@18.13.0 --ignore-scripts
 
-      # Submits a new Android preview build to EAS for the exact commit under
-      # test and blocks until it finishes (eas build waits by default). This
-      # guarantees the binary under test matches this PR's code, instead of
-      # trusting whatever build happened to be "latest finished" on EAS.
+      # Reuses an existing finished EAS build for this exact commit when one
+      # exists, instead of always submitting a new one. This still guarantees
+      # the binary under test matches this PR's code (the lookup is keyed on
+      # commit SHA), while avoiding unnecessary EAS build-minute usage when a
+      # matching build already exists (e.g. a workflow re-run).
       - name: Build Android app on EAS
         working-directory: mobile
         env:
@@ -411,13 +430,30 @@ jobs:
         run: |
           mkdir -p e2e/artifacts
 
-          if ! BUILD_JSON=$(eas build \
+          echo "Looking for an existing finished build for commit ${GITHUB_SHA} (android/simulator)..."
+          EXISTING_JSON=$(eas build:list \
             --platform android \
-            --profile simulator \
-            --non-interactive \
-            --json); then
-            echo "::error::EAS build failed or did not finish successfully."
-            exit 1
+            --buildProfile simulator \
+            --status finished \
+            --nonInteractive \
+            --json \
+            --limit 30 2>/dev/null || echo '[]')
+
+          BUILD_JSON=$(echo "$EXISTING_JSON" | jq --arg sha "$GITHUB_SHA" \
+            '[.[] | select(.gitCommitHash == $sha)] | .[0:1]')
+
+          if [ "$(echo "$BUILD_JSON" | jq 'length')" -gt 0 ]; then
+            echo "Reusing existing EAS build for commit ${GITHUB_SHA}."
+          else
+            echo "No existing build found for this commit, submitting a new one."
+            if ! BUILD_JSON=$(eas build \
+              --platform android \
+              --profile simulator \
+              --non-interactive \
+              --json); then
+              echo "::error::EAS build failed or did not finish successfully."
+              exit 1
+            fi
           fi
 
           STATUS=$(echo "$BUILD_JSON" | jq -r '.[0].status')


### PR DESCRIPTION
## Summary
- The iOS and Android E2E jobs in `mobile-e2e.yml` previously called `eas build` unconditionally on every run, consuming EAS build minutes even when a build for the exact same commit already existed (e.g. re-running the workflow).
- Both jobs now query `eas build:list` for a finished build matching `$GITHUB_SHA` and reuse it if found; only when no matching build exists does it fall back to submitting a new `eas build`.
- This keeps the guarantee that the binary under test matches the commit under test (the lookup is keyed on the commit SHA), while cutting down on unnecessary EAS build usage/limits.

## Test plan
- [ ] Push a commit and confirm the workflow submits a new build when none exists for that commit
- [ ] Re-run the workflow on the same commit and confirm it logs "Reusing existing EAS build..." and skips submitting a new build
- [ ] Confirm iOS/Android E2E tests still pass end-to-end with the reused/new build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined mobile app validation by reusing completed builds for the same code revision when available.
  - Reduced redundant build submissions during iOS and Android end-to-end testing.
  - Preserved automatic build creation when a matching completed build is unavailable.
  - Existing test status reporting and artifact collection remain unchanged.
  - No user-facing application functionality or behavior has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->